### PR TITLE
Fix for dynamic finders with grails 2 style unit tests and JTS geometry type (Point)

### DIFF
--- a/hibernate-spatial/grails-app/domain/PointOfInterest.groovy
+++ b/hibernate-spatial/grails-app/domain/PointOfInterest.groovy
@@ -1,0 +1,6 @@
+import com.vividsolutions.jts.geom.Point
+
+class PointOfInterest 
+{
+	Point location
+}

--- a/hibernate-spatial/scripts/_Events.groovy
+++ b/hibernate-spatial/scripts/_Events.groovy
@@ -1,0 +1,7 @@
+eventTestPhaseStart = { phase ->
+	if (phase == "unit") {
+		event "StatusUpdate", ["configuring JTS support for simple datastore"]
+		def marshallerClass = classLoader.loadClass("grails.plugin.hibernatespatial.simpledatastore.SimpleMapJTSMarshaller")
+		marshallerClass.initialize()
+	}
+}

--- a/hibernate-spatial/src/groovy/grails/plugin/hibernatespatial/simpledatastore/SimpleMapJTSMarshaller.groovy
+++ b/hibernate-spatial/src/groovy/grails/plugin/hibernatespatial/simpledatastore/SimpleMapJTSMarshaller.groovy
@@ -1,0 +1,51 @@
+package grails.plugin.hibernatespatial.simpledatastore
+
+import org.grails.datastore.mapping.engine.types.AbstractMappingAwareCustomTypeMarshaller
+import org.grails.datastore.mapping.query.Query
+import org.grails.datastore.mapping.simple.query.SimpleMapResultList
+import org.grails.datastore.mapping.model.*
+import com.vividsolutions.jts.geom.*
+
+/**
+ * A marshaller for Joda-Time types usable in the Simple Map datastore.
+ * @param < T >
+ */
+class SimpleMapJTSMarshaller<T> extends AbstractMappingAwareCustomTypeMarshaller<T, Map, SimpleMapResultList> {
+
+    SimpleMapJTSMarshaller(Class<T> targetType) {
+        super(targetType)
+    }
+
+    @Override
+    protected Object writeInternal(PersistentProperty property, String key, T value, Map nativeTarget) {
+        nativeTarget[key] = value
+    }
+
+    @Override
+    protected T readInternal(PersistentProperty property, String key, Map nativeSource) {
+        nativeSource[key]
+    }
+
+    private static final SUPPORTED_OPERATIONS = [Query.Equals, Query.NotEquals]
+    private static final SUPPORTED_OPERATIONS_FOR_COMPARABLE = SUPPORTED_OPERATIONS
+
+    @Override
+    protected void queryInternal(PersistentProperty property, String key, Query.PropertyCriterion criterion, SimpleMapResultList nativeQuery) {
+        def supportedOperations = Comparable.isAssignableFrom(targetType) ? SUPPORTED_OPERATIONS_FOR_COMPARABLE : SUPPORTED_OPERATIONS
+        def op = criterion.getClass()
+        if (op in supportedOperations) {
+            Closure handler = nativeQuery.query.handlers[op]
+            nativeQuery.results << handler.call(criterion, property)
+        } else {
+            throw new RuntimeException("unsupported query type $criterion for property $property")
+        }
+    }
+
+    static final Iterable<Class> SUPPORTED_TYPES = [Geometry, GeometryCollection, LineString, Point, Polygon, MultiLineString, MultiPoint, MultiPolygon, LinearRing, Puntal, Lineal, Polygonal]
+
+    static initialize() {
+        for (type in SUPPORTED_TYPES) {
+            MappingFactory.registerCustomType(new SimpleMapJTSMarshaller(type))
+        }
+    }
+}

--- a/hibernate-spatial/test/unit/PointOfInterestTests.groovy
+++ b/hibernate-spatial/test/unit/PointOfInterestTests.groovy
@@ -1,0 +1,22 @@
+import com.vividsolutions.jts.geom.*
+
+/**
+ * This test only fails when done as a grails 2 style tests (using @TestFor etc.) rather than 
+ * a grails 1 style test (i.e. extending GrailsUnitTest, mockDomain etc).
+ */
+@TestFor(PointOfInterest)
+class PointOfInterestTests
+{
+    void testFindByLocation()
+	{
+		Point location = new GeometryFactory().createPoint(new Coordinate(12f, 34f))
+		PointOfInterest placeOne = new PointOfInterest(location: location)
+		placeOne.save()
+
+		PointOfInterest foundPlace = PointOfInterest.findByLocation(location)
+		assertNotNull(foundPlace)
+
+		PointOfInterest notFoundPlace = PointOfInterest.findByLocation(new GeometryFactory().createPoint(new Coordinate(1f, 2f)))
+		assertNull(notFoundPlace)
+    }
+}


### PR DESCRIPTION
Hi there,

Ran in to a problem with dynamic finders, grails 2 and JTS types:

org.springframework.dao.InvalidDataAccessResourceUsageException: Cannot query [hibernate_spatial_unit_test.PointOfInterest] on non-existent property: location
at org.grails.datastore.mapping.simple.query.SimpleMapQuery.getValidProperty(SimpleMapQuery.groovy:726)
at org.grails.datastore.mapping.simple.query.SimpleMapQuery.executeSubQueryInternal(SimpleMapQuery.groovy:664)
at org.grails.datastore.mapping.simple.query.SimpleMapQuery.executeSubQuery(SimpleMapQuery.groovy:650)
at org.grails.datastore.mapping.simple.query.SimpleMapQuery.executeQuery(SimpleMapQuery.groovy:63)
at org.grails.datastore.mapping.query.Query.list(Query.java:486)
at org.grails.datastore.gorm.finders.AbstractFindByFinder.invokeQuery(AbstractFindByFinder.java:34)
at org.grails.datastore.gorm.finders.AbstractFindByFinder$1.doInSession(AbstractFindByFinder.java:26)
at org.grails.datastore.mapping.core.DatastoreUtils.execute(DatastoreUtils.java:301)
at org.grails.datastore.gorm.finders.AbstractFinder.execute(AbstractFinder.java:40)
at org.grails.datastore.gorm.finders.AbstractFindByFinder.doInvokeInternal(AbstractFindByFinder.java:24)
at org.grails.datastore.gorm.finders.DynamicFinder.invoke(DynamicFinder.java:151)
at org.grails.datastore.gorm.finders.DynamicFinder.invoke(DynamicFinder.java:352)
at org.grails.datastore.gorm.GormStaticApi.methodMissing(GormStaticApi.groovy:108)
at PointOfInterestTests.testFindByLocation(PointOfInterestTests.groovy:14)

Comment out/delete "scripts/_Events.groovy" to re-create the bug.

Not sure if you want to include fix in the plugin, but here it is anyway...

Cheers,
Jon
